### PR TITLE
refactor: `synced` => `sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Customize behaviour by creating a `version.config.json` file in your project roo
   "updateChangelog": true,
   "changelogFormat": "keep-a-changelog",
   "strictReachable": false,
-  "synced": true,
+  "sync": true,
   "skip": [
     "docs",
     "e2e"
@@ -160,7 +160,7 @@ Customize behaviour by creating a `version.config.json` file in your project roo
   - `paths`: Directories to search for Cargo.toml files (optional)
 
 #### Monorepo-Specific Options
-- `synced`: Whether all packages should be versioned together (default: true)
+- `sync`: Whether all packages should be versioned together (default: true)
 - `skip`: Array of package names or patterns to exclude from versioning. Supports exact names, scope wildcards, path patterns, and global wildcards (e.g., ["@scope/package-a", "@scope/*", "packages/**/*"])
 - `packages`: Array of package names or patterns to target for versioning. Supports exact names, scope wildcards, path patterns and global wildcards (e.g., ["@scope/package-a", "@scope/*", "*"])
 - `mainPackage`: Package name whose commit history should drive version determination
@@ -234,7 +234,7 @@ This option works in conjunction with `tagTemplate` to control tag formatting. T
 
 **Examples:**
 
-For single-package repositories or synced monorepos:
+For single-package repositories or sync monorepos:
 ```json
 {
   "packageSpecificTags": true,
@@ -253,8 +253,8 @@ For global versioning:
 Creates tags like `v1.2.3`
 
 **Important Notes:**
-- In **synced mode** with a single package, `packageSpecificTags: true` will use the package name even though all packages are versioned together
-- In **synced mode** with multiple packages, package names are not used regardless of the setting
+- In **sync mode** with a single package, `packageSpecificTags: true` will use the package name even though all packages are versioned together
+- In **sync mode** with multiple packages, package names are not used regardless of the setting
 - In **async mode**, each package gets its own tag when `packageSpecificTags` is enabled
 
 With package-specific tagging enabled, the tool will:
@@ -269,7 +269,7 @@ With package-specific tagging enabled, the tool will:
 1.  **Conventional Commits:** Analyzes commit messages (like `feat:`, `fix:`, `BREAKING CHANGE:`) since the last tag.
 2.  **Branch Pattern:** Determines the bump based on the current or recently merged branch name matching predefined patterns.
 
-For a detailed explanation of these concepts and monorepo modes (Synced vs. Async), see [Versioning Strategies and Concepts](./docs/versioning.md).
+For a detailed explanation of these concepts and monorepo modes (Sync vs. Async), see [Versioning Strategies and Concepts](./docs/versioning.md).
 
 ## Documentation
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -334,7 +334,7 @@ Warning: Your tagTemplate contains ${packageName} but no package name is availab
 This will result in an empty package name in the tag (e.g., "@v1.0.0" instead of "my-package@v1.0.0").
 
 To fix this:
-• If using synced mode: Set "packageSpecificTags": true in your config to enable package names in tags
+• If using sync mode: Set "packageSpecificTags": true in your config to enable package names in tags
 • If you want global tags: Remove ${packageName} from your tagTemplate (e.g., use "${prefix}${version}")
 • If using single/async mode: Ensure your package.json has a valid "name" field
 ```
@@ -344,7 +344,7 @@ To fix this:
 1. **For Synced Mode with Package Names**: Enable package-specific tags
    ```json
    {
-     "synced": true,
+     "sync": true,
      "packageSpecificTags": true,
      "tagTemplate": "${packageName}@${prefix}${version}"
    }
@@ -397,11 +397,11 @@ For global commit messages, use templates without `${packageName}`:
 
 ## Monorepo Versioning Modes
 
-While primarily used for single packages now, `package-versioner` retains options for monorepo workflows, controlled mainly by the `synced` flag in `version.config.json`.
+While primarily used for single packages now, `package-versioner` retains options for monorepo workflows, controlled mainly by the `sync` flag in `version.config.json`.
 
-### Synced Mode (`synced: true`)
+### Sync Mode (`sync: true`)
 
-This is the default if the `synced` flag is present and true.
+This is the default if the `sync` flag is present and true.
 
 -   **Behaviour:** The tool calculates **one** version bump based on the overall history (or branch pattern). This single new version is applied to **all** packages within the repository (or just the root `package.json` if not a structured monorepo). A single Git tag is created.
 -   **Tag Behaviour:** 
@@ -409,7 +409,7 @@ This is the default if the `synced` flag is present and true.
     - In **single-package repositories**: Respects the `packageSpecificTags` setting - can create either `v1.2.3` or `package-name@v1.2.3`
 -   **Use Case:** Suitable for monorepos where all packages are tightly coupled and released together with the same version number. Also the effective mode for single-package repositories.
 
-### Async Mode (`synced: false`)
+### Async Mode (`sync: false`)
 
 *(Note: This mode relies heavily on monorepo tooling and structure, like `pnpm workspaces` and correctly configured package dependencies.)*
 

--- a/package-versioner.schema.json
+++ b/package-versioner.schema.json
@@ -41,7 +41,7 @@
       "description": "The main branch for versioning",
       "default": "main"
     },
-    "synced": {
+    "sync": {
       "type": "boolean",
       "default": false,
       "description": "Whether packages should be versioned together"

--- a/src/core/versionEngine.ts
+++ b/src/core/versionEngine.ts
@@ -147,7 +147,7 @@ export class VersionEngine {
 
   /**
    * Change the current strategy
-   * @param strategyType The strategy type to use: 'synced', 'single', or 'async'
+   * @param strategyType The strategy type to use: 'sync', 'single', or 'async'
    */
   public setStrategy(strategyType: StrategyType): void {
     this.currentStrategy = this.strategies[strategyType];

--- a/src/core/versionStrategies.ts
+++ b/src/core/versionStrategies.ts
@@ -24,7 +24,7 @@ import type { PackagesWithRoot } from './versionEngine.js';
 /**
  * Available strategy types
  */
-export type StrategyType = 'synced' | 'single' | 'async';
+export type StrategyType = 'sync' | 'single' | 'async';
 
 /**
  * Strategy function type
@@ -41,9 +41,9 @@ function shouldProcessPackage(pkg: Package, config: Config): boolean {
 }
 
 /**
- * Create a synced versioning strategy function
+ * Create a sync versioning strategy function
  */
-export function createSyncedStrategy(config: Config): StrategyFunction {
+export function createSyncStrategy(config: Config): StrategyFunction {
   return async (packages: PackagesWithRoot): Promise<void> => {
     try {
       const {
@@ -178,7 +178,7 @@ export function createSyncedStrategy(config: Config): StrategyFunction {
       }
 
       // Create tag using the template
-      // In synced mode with single package, respect packageSpecificTags setting
+      // In sync mode with single package, respect packageSpecificTags setting
       let tagPackageName: string | null = null;
       let commitPackageName: string | undefined;
 
@@ -485,8 +485,8 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
  * The CLI will override this based on resolved packages.
  */
 export function createStrategy(config: Config): StrategyFunction {
-  if (config.synced) {
-    return createSyncedStrategy(config);
+  if (config.sync) {
+    return createSyncStrategy(config);
   }
 
   // Default to async strategy - the CLI will determine the actual strategy
@@ -499,7 +499,7 @@ export function createStrategy(config: Config): StrategyFunction {
  */
 export function createStrategyMap(config: Config): Record<StrategyType, StrategyFunction> {
   return {
-    synced: createSyncedStrategy(config),
+    sync: createSyncStrategy(config),
     single: createSingleStrategy(config),
     async: createAsyncStrategy(config),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export async function run(): Promise<void> {
       .option('-d, --dry-run', 'Dry run (no changes made)', false)
       .option('-b, --bump <type>', 'Specify bump type (patch|minor|major)')
       .option('-p, --prerelease [identifier]', 'Create prerelease version')
-      .option('-s, --synced', 'Use synchronized versioning across all packages')
+      .option('-s, --sync', 'Use synchronized versioning across all packages')
       .option('-j, --json', 'Output results as JSON', false)
       .option('-t, --target <packages>', 'Comma-delimited list of package names to target')
       .option('--project-dir <path>', 'Project directory to run commands in', process.cwd())
@@ -91,7 +91,7 @@ export async function run(): Promise<void> {
 
           // Override config with CLI options
           if (options.dryRun) config.dryRun = true;
-          if (options.synced) config.synced = true; // Allow forcing sync mode
+          if (options.sync) config.sync = true; // Allow forcing sync mode
           if (options.bump) config.type = options.bump;
           if (options.prerelease) {
             config.prereleaseIdentifier = options.prerelease === true ? 'next' : options.prerelease;
@@ -112,12 +112,12 @@ export async function run(): Promise<void> {
 
           log(`Resolved ${resolvedCount} packages from workspace`, 'debug');
           log(`Config packages: ${JSON.stringify(config.packages)}`, 'debug');
-          log(`Config synced: ${config.synced}`, 'debug');
+          log(`Config sync: ${config.sync}`, 'debug');
 
           // Determine strategy based on resolved package count
-          if (config.synced) {
-            log('Using synced versioning strategy.', 'info');
-            engine.setStrategy('synced');
+          if (config.sync) {
+            log('Using sync versioning strategy.', 'info');
+            engine.setStrategy('sync');
             await engine.run(pkgsResult);
           } else if (resolvedCount === 1) {
             // Check if the resolved package is a real package (not a glob pattern)

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export interface Config extends VersionConfigBase {
   packageSpecificTags?: boolean; // Default: false - Set to true to enable package-specific tagging
 
   preset: string;
-  synced: boolean;
+  sync: boolean;
   packages: string[];
   mainPackage?: string; // The package to use for version determination
   updateInternalDependencies: 'major' | 'minor' | 'patch' | 'no-internal-update';
@@ -118,7 +118,7 @@ export interface TagFormat {
   tagTemplate?: string;
   prefix?: string;
   name?: string;
-  synced: boolean;
+  sync: boolean;
 }
 
 /**

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -35,7 +35,7 @@ export function formatTag(
       'Warning: Your tagTemplate contains ${packageName} but no package name is available.\n' +
         'This will result in an empty package name in the tag (e.g., "@v1.0.0" instead of "my-package@v1.0.0").\n\n' +
         'To fix this:\n' +
-        '• If using synced mode: Set "packageSpecificTags": true in your config to enable package names in tags\n' +
+        '• If using sync mode: Set "packageSpecificTags": true in your config to enable package names in tags\n' +
         '• If you want global tags: Remove ${packageName} from your tagTemplate (e.g., use "${prefix}${version}")\n' +
         '• If using single/async mode: Ensure your package.json has a valid "name" field',
       'warning',
@@ -72,7 +72,7 @@ export function formatCommitMessage(
       'Warning: Your commitMessage template contains ${packageName} but no package name is available.\n' +
         'This will result in an empty package name in the commit message (e.g., "Release @v1.0.0").\n\n' +
         'To fix this:\n' +
-        '• If using synced mode: Set "packageSpecificTags": true to enable package names in commits\n' +
+        '• If using sync mode: Set "packageSpecificTags": true to enable package names in commits\n' +
         '• If you want generic commit messages: Remove ${packageName} from your commitMessage template\n' +
         '• If using single/async mode: Ensure your package.json has a valid "name" field',
       'warning',

--- a/test/integration/versioning.spec.ts
+++ b/test/integration/versioning.spec.ts
@@ -146,7 +146,7 @@ describe('Monorepo Project', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       packages: ['packages/*'],
-      synced: true,
+      sync: true,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',
@@ -158,7 +158,7 @@ describe('Monorepo Project', () => {
     cleanupTempDir(tempDir);
   });
 
-  it('should update all packages with synced versioning', () => {
+  it('should update all packages with sync versioning', () => {
     // Make a change in package-a
     const fileA = join(tempDir, 'packages/package-a/index.js');
     require('node:fs').writeFileSync(fileA, 'console.log("Hello from A");');
@@ -644,7 +644,7 @@ describe('Packages Filtering Tests', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       packages: ['packages/*'],
-      synced: false,
+      sync: false,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',
@@ -682,7 +682,7 @@ describe('Packages Filtering Tests', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       packages: [], // Empty array should process all packages
-      synced: false,
+      sync: false,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',
@@ -721,7 +721,7 @@ describe('Packages Filtering Tests', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       // packages property not specified
-      synced: false,
+      sync: false,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',
@@ -760,7 +760,7 @@ describe('Packages Filtering Tests', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       packages: ['@test/package-a', 'standalone-package'],
-      synced: false,
+      sync: false,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',
@@ -799,7 +799,7 @@ describe('Packages Filtering Tests', () => {
     createVersionConfig(tempDir, {
       preset: 'conventional-commits',
       packages: ['@test/*'],
-      synced: false,
+      sync: false,
       versionPrefix: 'v',
       tagTemplate: '${prefix}${version}',
       packageTagTemplate: '${packageName}@${prefix}${version}',

--- a/test/unit/cli.spec.ts
+++ b/test/unit/cli.spec.ts
@@ -59,7 +59,7 @@ describe('CLI Interface', () => {
   let mockProcess: Partial<NodeJS.Process>;
   const originalProcess: NodeJS.Process = process;
   const mockConfig: Partial<Config> = {
-    synced: false,
+    sync: false,
     packages: ['package-a'],
     dryRun: false,
   };

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -28,7 +28,7 @@ describe('Config', () => {
       packageTagTemplate: '${packageName}@${prefix}${version}',
       versionStrategy: 'branchPattern' as const,
       baseBranch: 'main',
-      synced: true,
+      sync: true,
       branchPattern: [],
       skip: [],
       updateInternalDependencies: 'no-internal-update' as const,

--- a/test/unit/core/versionEngine.spec.ts
+++ b/test/unit/core/versionEngine.spec.ts
@@ -19,7 +19,7 @@ vi.mock('node:process', () => ({
 
 describe('Version Engine', () => {
   // Mock strategies
-  const syncedStrategyMock = vi.fn().mockResolvedValue(undefined);
+  const syncStrategyMock = vi.fn().mockResolvedValue(undefined);
   const singleStrategyMock = vi.fn().mockResolvedValue(undefined);
   const asyncStrategyMock = vi.fn().mockResolvedValue(undefined);
 
@@ -41,7 +41,7 @@ describe('Version Engine', () => {
   // Default config for tests
   const defaultConfig: Partial<Config> = {
     preset: 'conventional-commits',
-    synced: true,
+    sync: true,
     versionPrefix: 'v',
     tagTemplate: '${packageName}@${prefix}${version}',
     baseBranch: 'main',
@@ -56,8 +56,8 @@ describe('Version Engine', () => {
     vi.mocked(mockCwd, { partial: true }).mockReturnValue('/test/workspace');
 
     // Setup strategy mocks
-    vi.mocked(strategyModule.createSyncedStrategy, { partial: true }).mockReturnValue(
-      syncedStrategyMock,
+    vi.mocked(strategyModule.createSyncStrategy, { partial: true }).mockReturnValue(
+      syncStrategyMock,
     );
     vi.mocked(strategyModule.createSingleStrategy, { partial: true }).mockReturnValue(
       singleStrategyMock,
@@ -65,9 +65,9 @@ describe('Version Engine', () => {
     vi.mocked(strategyModule.createAsyncStrategy, { partial: true }).mockReturnValue(
       asyncStrategyMock,
     );
-    vi.mocked(strategyModule.createStrategy, { partial: true }).mockReturnValue(syncedStrategyMock);
+    vi.mocked(strategyModule.createStrategy, { partial: true }).mockReturnValue(syncStrategyMock);
     vi.mocked(strategyModule.createStrategyMap, { partial: true }).mockReturnValue({
-      synced: syncedStrategyMock,
+      sync: syncStrategyMock,
       single: singleStrategyMock,
       async: asyncStrategyMock,
     });
@@ -89,7 +89,7 @@ describe('Version Engine', () => {
 
     it('should set default preset if not provided', () => {
       const config: Partial<Config> = {
-        synced: true,
+        sync: true,
         versionPrefix: 'v',
         tagTemplate: '${packageName}@${prefix}${version}',
         baseBranch: 'main',
@@ -296,19 +296,19 @@ describe('Version Engine', () => {
     it('should get workspace packages and execute the current strategy', async () => {
       const engine = new VersionEngine(defaultConfig as Config);
       await engine.run(mockPackages);
-      expect(syncedStrategyMock).toHaveBeenCalledWith(mockPackages, []);
+      expect(syncStrategyMock).toHaveBeenCalledWith(mockPackages, []);
     });
 
     it('should pass targets to the strategy function', async () => {
       const engine = new VersionEngine(defaultConfig as Config);
       const targets = ['package-a'];
       await engine.run(mockPackages, targets);
-      expect(syncedStrategyMock).toHaveBeenCalledWith(mockPackages, targets);
+      expect(syncStrategyMock).toHaveBeenCalledWith(mockPackages, targets);
     });
 
     it('should propagate errors thrown by the strategy', async () => {
       const error = new Error('Strategy failed');
-      syncedStrategyMock.mockRejectedValue(error);
+      syncStrategyMock.mockRejectedValue(error);
       const engine = new VersionEngine(defaultConfig as Config);
       await expect(engine.run(mockPackages)).rejects.toThrow('Strategy failed');
     });
@@ -340,7 +340,7 @@ describe('Version Engine', () => {
     it('should process all packages', async () => {
       const engine = new VersionEngine(defaultConfig as Config);
       await engine.run(mockPackages);
-      expect(syncedStrategyMock).toHaveBeenCalledWith(mockPackages, []);
+      expect(syncStrategyMock).toHaveBeenCalledWith(mockPackages, []);
     });
   });
 
@@ -348,17 +348,17 @@ describe('Version Engine', () => {
     it('should change the current strategy', async () => {
       const engine = new VersionEngine(defaultConfig as Config);
 
-      // Initially synced strategy should be used
+      // Initially sync strategy should be used
       await engine.run(mockPackages);
-      expect(syncedStrategyMock).toHaveBeenCalled();
+      expect(syncStrategyMock).toHaveBeenCalled();
 
       // Change to async strategy
       engine.setStrategy('async');
-      syncedStrategyMock.mockClear();
+      syncStrategyMock.mockClear();
 
       // Now async strategy should be used
       await engine.run(mockPackages);
-      expect(syncedStrategyMock).not.toHaveBeenCalled();
+      expect(syncStrategyMock).not.toHaveBeenCalled();
       expect(asyncStrategyMock).toHaveBeenCalled();
     });
   });

--- a/test/unit/core/versionStrategies.spec.ts
+++ b/test/unit/core/versionStrategies.spec.ts
@@ -146,19 +146,19 @@ describe('Version Strategies', () => {
     });
   });
 
-  describe('createSyncedStrategy', () => {
+  describe('createSyncStrategy', () => {
     it('should update all packages to the same version', async () => {
       // Setup
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
         commitMessage: 'chore(release): v${version}',
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify
       expect(git.getLatestTag).toHaveBeenCalled();
@@ -191,14 +191,14 @@ describe('Version Strategies', () => {
       // Setup with mainPackage
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
         mainPackage: 'package-b',
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify that version calculation used package-b
       expect(calculator.calculateVersion).toHaveBeenCalledWith(
@@ -219,14 +219,14 @@ describe('Version Strategies', () => {
       // Setup with non-existent mainPackage
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
         mainPackage: 'package-z',
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify that version calculation used root package
       expect(calculator.calculateVersion).toHaveBeenCalledWith(
@@ -248,17 +248,17 @@ describe('Version Strategies', () => {
       // Setup
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
         commitMessage: 'chore: release ${packageName}@${version} [skip-ci]',
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify that formatCommitMessage was called with the right template and parameters
-      // The synced strategy no longer suppresses warnings by default
+      // The sync strategy no longer suppresses warnings by default
       expect(formatting.formatCommitMessage).toHaveBeenCalledWith(
         'chore: release ${packageName}@${version} [skip-ci]',
         '1.1.0',
@@ -273,13 +273,13 @@ describe('Version Strategies', () => {
 
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify no updates were made
       expect(packageManagement.updatePackageVersion).not.toHaveBeenCalled();
@@ -290,14 +290,14 @@ describe('Version Strategies', () => {
     it('should respect skip configuration', async () => {
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
         skip: ['package-b'],
       };
 
-      const syncedStrategy = strategies.createSyncedStrategy(config as Config);
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
 
       // Execute
-      await syncedStrategy(mockPackages);
+      await syncStrategy(mockPackages);
 
       // Verify package-b was skipped
       expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(rootPackagePath, '1.1.0');
@@ -544,15 +544,15 @@ describe('Version Strategies', () => {
   });
 
   describe('createStrategy', () => {
-    it('should return synced strategy when synced is true', () => {
+    it('should return sync strategy when sync is true', () => {
       const config: Partial<Config> = {
         ...defaultConfig,
-        synced: true,
+        sync: true,
       };
 
       // Since we've already tested the individual strategies, just verify the strategy map exists
       const strategyMap = strategies.createStrategyMap(config as Config);
-      expect(strategyMap).toHaveProperty('synced');
+      expect(strategyMap).toHaveProperty('sync');
     });
 
     it('should return async strategy when packages has one item (CLI will handle strategy selection)', () => {
@@ -605,7 +605,7 @@ describe('Version Strategies', () => {
       const strategyMap = strategies.createStrategyMap(config as Config);
 
       // Instead of checking function calls, check the structure of the returned map
-      expect(strategyMap).toHaveProperty('synced');
+      expect(strategyMap).toHaveProperty('sync');
       expect(strategyMap).toHaveProperty('single');
       expect(strategyMap).toHaveProperty('async');
     });

--- a/test/unit/package/packageProcessor.spec.ts
+++ b/test/unit/package/packageProcessor.spec.ts
@@ -110,7 +110,7 @@ describe('Package Processor', () => {
 
   // Mock config
   const mockConfig: Config = {
-    synced: false,
+    sync: false,
     updateInternalDependencies: 'patch',
     preset: 'conventional',
     versionPrefix: 'v',

--- a/test/unit/utils/formatting.spec.ts
+++ b/test/unit/utils/formatting.spec.ts
@@ -69,7 +69,7 @@ describe('formatting', () => {
         'Warning: Your tagTemplate contains ${packageName} but no package name is available.\n' +
           'This will result in an empty package name in the tag (e.g., "@v1.0.0" instead of "my-package@v1.0.0").\n\n' +
           'To fix this:\n' +
-          '• If using synced mode: Set "packageSpecificTags": true in your config to enable package names in tags\n' +
+          '• If using sync mode: Set "packageSpecificTags": true in your config to enable package names in tags\n' +
           '• If you want global tags: Remove ${packageName} from your tagTemplate (e.g., use "${prefix}${version}")\n' +
           '• If using single/async mode: Ensure your package.json has a valid "name" field',
         'warning',
@@ -186,7 +186,7 @@ describe('formatting', () => {
         'Warning: Your commitMessage template contains ${packageName} but no package name is available.\n' +
           'This will result in an empty package name in the commit message (e.g., "Release @v1.0.0").\n\n' +
           'To fix this:\n' +
-          '• If using synced mode: Set "packageSpecificTags": true to enable package names in commits\n' +
+          '• If using sync mode: Set "packageSpecificTags": true to enable package names in commits\n' +
           '• If you want generic commit messages: Remove ${packageName} from your commitMessage template\n' +
           '• If using single/async mode: Ensure your package.json has a valid "name" field',
         'warning',


### PR DESCRIPTION
Renaming `synced` to `sync` for the following reasons

  1. Grammatical correctness: It's an adjective describing the versioning mode, not a past tense verb
  2. Conciseness: "sync" is shorter and more direct than "synced"
  3. Industry convention: Terms like "sync versioning" are more standard than "synced versioning"
  4. Clarity: The option -s, --sync with description "Use synchronized versioning across all packages" is clearer - it
  describes the current state/mode rather than implying something that happened in the past

  The CLI option now reads more naturally as "sync versioning strategy" rather than "synced versioning strategy", which
   better describes what the tool does (keeps packages in sync) rather than what it did (made them synced).